### PR TITLE
Migrate hosting from Netlify to GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+kojima.oscorp.net


### PR DESCRIPTION
## Summary

- Adds a `CNAME` file telling GitHub Pages to serve the site at `kojima.oscorp.net`
- This is step 1 of the Netlify → GitHub Pages migration

## Manual steps after merge

These can't be automated and need to happen in order:

1. **Enable GitHub Pages** — Settings → Pages → Source: *Deploy from a branch*, Branch: `main`, Folder: `/ (root)`. Save.
2. **Wait for the first Pages build**, confirm it loads at `spaceninja.github.io/kojima-name-generator/`.
3. **CloudFlare DNS**: replace existing `kojima.oscorp.net` record with CNAME → `spaceninja.github.io`, proxy = DNS-only (grey cloud). _(I'll do this via API.)_
4. **Pages settings → Custom domain**: enter `kojima.oscorp.net`, save. Wait ~5–15 min for Let's Encrypt cert.
5. **Check "Enforce HTTPS"** once the cert provisions.
6. **Verify** with `curl -sI https://kojima.oscorp.net/` — expect `server: GitHub.com` in response.
7. **Netlify**: unlink the repo and delete the site.
8. **Renovate**: remove this repo from the Renovate dashboard / config (with `package.json` gone, leaving it enabled would just generate errors).

## Test plan

- [ ] Site loads at `spaceninja.github.io/kojima-name-generator/` after Pages is enabled
- [ ] Site loads at `https://kojima.oscorp.net/` after DNS + custom domain
- [ ] `curl -sI` returns `server: GitHub.com`
- [ ] Twitter and Facebook share buttons produce valid URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)